### PR TITLE
feat: upgrade deprecated dms versions

### DIFF
--- a/src/variables.tf
+++ b/src/variables.tf
@@ -36,7 +36,7 @@ variable "availability_zone" {
 variable "engine_version" {
   type        = string
   description = "The engine version number of the replication instance"
-  default     = "3.4"
+  default     = "3.5.4"
 }
 
 variable "multi_az" {
@@ -60,7 +60,7 @@ variable "publicly_accessible" {
 variable "replication_instance_class" {
   type        = string
   description = "The compute and memory capacity of the replication instance as specified by the replication instance class"
-  default     = "dms.t2.small"
+  default     = "dms.t3.small"
 }
 
 variable "security_group_create_before_destroy" {


### PR DESCRIPTION
## what
* upgrades the default DMS engine version (old version is deprecated) -- this new version will last until at least 2026
* upgrades the default DMS instance machine type (old is deprecated)
## why
![image](https://github.com/user-attachments/assets/f877b5b9-0afb-4530-893b-6c2e1388a41a)
![image](https://github.com/user-attachments/assets/a9fb7a6a-d386-4201-89f3-a6c9435fcba8)
![image](https://github.com/user-attachments/assets/00eccd0e-3002-4c1f-a780-b10b336430be)


## references
https://docs.aws.amazon.com/dms/latest/userguide/CHAP_ReleaseNotes.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded the replication instance’s engine version to improve performance.
  - Updated default resource settings for enhanced reliability and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->